### PR TITLE
fix(highlights): set priority to not compete with string.bash

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,9 +1,11 @@
-[
+; note: all highlights are set to priority 101, for compatibility with bash injections in yaml
+([
   "${{"
   "}}"
 ] @keyword
+  (#set! priority 101))
 
-[
+([
   "&&"
   "||"
   "=="
@@ -16,52 +18,66 @@
   "-"
   "!"
 ] @operator
+  (#set! priority 101))
 
-[
+([
   "("
   ")"
   "["
   "]"
 ] @punctuation.bracket
+  (#set! priority 101))
 
-[
+([
   ","
   "."
 ] @punctuation.delimiter
+  (#set! priority 101))
 
-"*" @punctuation.special
+("*" @punctuation.special
+  (#set! priority 101))
 
-(number) @number
+((number) @number
+  (#set! priority 101))
 
-(identifier) @variable
+((identifier) @variable
+  (#set! priority 101))
 
 ; https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
 (dereference_expression
   object: (identifier) @module.builtin
   (#any-of? @module.builtin
     "github" "env" "vars" "job" "jobs" "steps" "runner" "secrets" "strategy" "matrix" "needs"
-    "inputs"))
+    "inputs")
+  (#set! priority 101))
 
-(dereference_expression
+((dereference_expression
   property: (identifier) @property)
+  (#set! priority 101))
 
-(function_call
+((function_call
   name: (identifier) @function.call)
+  (#set! priority 101))
 
 ; https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#functions
-(function_call
+((function_call
   name: (identifier) @function.builtin
   (#any-of? @function.builtin
     "contains" "startsWith" "endsWith" "format" "join" "toJSON" "fromJSON" "hashFiles" "success"
     "always" "cancelled" "failure"))
+  (#set! priority 101))
 
-[
+([
   (true)
   (false)
 ] @boolean
+  (#set! priority 101))
 
-(null) @constant.builtin
+((null) @constant.builtin
+  (#set! priority 101))
 
-(string) @string
+((string) @string
+  (#set! priority 101))
 
-(escape) @string.escape
+((escape) @string.escape
+  (#set! priority 101))


### PR DESCRIPTION
bash is injected by default in the neovim yaml configuration. bash strings will have the same priorities which causes flicker/unwanted behavior.

Set priorities to 101 for compatibility with the bash. Only content in between `${{ ... }}` is highlighted by this parser, so the two now play well together.